### PR TITLE
Update master branch checker to allow for main branch

### DIFF
--- a/master-branch-checker/pipe.sh
+++ b/master-branch-checker/pipe.sh
@@ -1,20 +1,22 @@
 #!/bin/sh
 set -e
 
-DIFF_FROM_MASTER=$(git rev-list --left-right --count HEAD...origin/master|awk '{print $2}')
+BRANCH_NAME=$(git branch | cut -c 3- | grep -E '^master$|^main$')
+
+DIFF_FROM_MASTER=$(git rev-list --left-right --count HEAD...origin/$BRANCH_NAME|awk '{print $2}')
 
 echo "----------------------------------------------------------------------------------------------------"
 echo "| SYKES BRANCH CHECKER                                                                             |"
 echo "----------------------------------------------------------------------------------------------------"
 
 if [ "$DIFF_FROM_MASTER" -gt "0" ]; then
-    echo "| Your build has failed because master has $DIFF_FROM_MASTER more changes than your current branch |"
+    echo "| Your build has failed because $BRANCH_NAME has $DIFF_FROM_MASTER more changes than your current branch |"
     echo "|                                                                                                  |"
-    echo "| You need to run 'git pull origin master' on your branch!                                         |"
+    echo "| You need to run 'git pull origin $BRANCH_NAME' on your branch!                                         |"
     echo "----------------------------------------------------------------------------------------------------"
     exit 1
 else
-    echo "| Your build is up to date with master well done!                                                   |"
+    echo "| Your build is up to date with $BRANCH_NAME well done!                                                   |"
     echo "----------------------------------------------------------------------------------------------------"
     exit 0
 fi

--- a/master-branch-checker/pipe.sh
+++ b/master-branch-checker/pipe.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-BRANCH_NAME=$(git branch | cut -c 3- | grep -E '^master$|^main$')
+BRANCH_NAME=$(git branch -r | grep -Po 'HEAD -> .*/\K.*$')
 
 DIFF_FROM_MASTER=$(git rev-list --left-right --count HEAD...origin/$BRANCH_NAME|awk '{print $2}')
 


### PR DESCRIPTION
Updates the master-branch-checker pipe to use either master or main as the "master branch".