### PR TITLE
mark atlassian pipeline agents as safe

### DIFF
--- a/master-branch-checker/pipe.sh
+++ b/master-branch-checker/pipe.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+git config --global --add safe.directory /opt/atlassian/pipelines/agent/build
+
 DIFF_FROM_MASTER=$(git rev-list --left-right --count HEAD...origin/master|awk '{print $2}')
 
 echo "----------------------------------------------------------------------------------------------------"


### PR DESCRIPTION
# Issue
Check was passing despite the error being thrown

```
Status: Downloaded newer image for sykescottages/bitbucket-pipes:master-branch-checker

fatal: detected dubious ownership in repository at '/opt/atlassian/pipelines/agent/build'

To add an exception for this directory, call:

git config --global --add safe.directory /opt/atlassian/pipelines/agent/build
```
	

Added git config line