### PR TITLE
Add pipe fails to the message

### DIFF
--- a/master-branch-checker/pipe.sh
+++ b/master-branch-checker/pipe.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -e
+set -eo pipefail
 
 git config --global --add safe.directory /opt/atlassian/pipelines/agent/build
 


### PR DESCRIPTION
We were succeeding before when the first command failed.

Eg https://www.jdoodle.com/ia/1D3j

```
#!/bin/bash
#set -eo pipefail
set -e
TEST=$(exit 1 | echo "Hi")
echo $?
```